### PR TITLE
Add server name hash config

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -133,6 +133,13 @@ http {
   tcp_nopush      on;
   {% endblock %}
 
+  {% block advanced_config -%}
+  # Advanced config
+  # As we have numerous server_names we need to increase the hash max size
+  # Ref: http://nginx.org/en/docs/http/server_names.html#optimization
+  server_names_hash_max_size 512;
+  {% endblock -%}
+
   {% block compression -%}
   # Compression
 


### PR DESCRIPTION
The `server_names_hash_max_size` is usually configured according to the CPU. However we reached our maximum number of server names so we needed to manually override this.

Extra care will have to be taken in future Trellis updates so as not to remove this setting. This is also a quick fix, and not final. Performance is going to take a hit with this setting in place so this number needs bringing down as much as possible in a future commit

Ref: http://nginx.org/en/docs/http/server_names.html#optimization

Original in https://github.com/Fatsoma/wp-public-3/pull/791