### PR TITLE
Remove TLS protocol 1.0 and update ciphers list

### DIFF
--- a/roles/nginx/templates/h5bp/directive-only/ssl.conf
+++ b/roles/nginx/templates/h5bp/directive-only/ssl.conf
@@ -1,9 +1,9 @@
 # Protect against the BEAST and POODLE attacks by not using SSLv3 at all. If you need to support older browsers (IE6) you may need to add
 # SSLv3 to the list of protocols below.
-ssl_protocols              TLSv1 TLSv1.1 TLSv1.2;
+ssl_protocols              TLSv1.1 TLSv1.2;
 
-# Ciphers set to best allow protection from Beast, while providing forwarding secrecy, as defined by Mozilla (Intermediate Set) - https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx
-ssl_ciphers                ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS;
+# Ciphers set to best allow protection from BEAST and POODLE, while providing forwarding secrecy
+ssl_ciphers                ECDHE+AES:!SHA;
 ssl_prefer_server_ciphers  on;
 
 # Optimize SSL by caching session parameters for 10 minutes. This cuts down on the number of expensive SSL handshakes.


### PR DESCRIPTION
Remove support for TLS 1.0 as vulnerable to POODLE attack.

Update cipher suites to ECDHE+AES:!SHA as subset of those recommended by [Mozilla Intermediate compatibility](https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28default.29) that support forward secrecy.