### PR TITLE
Add rsync exclude file

### DIFF
--- a/.rsync-exclude
+++ b/.rsync-exclude
@@ -1,0 +1,21 @@
+# Excludes:
+/.git
+/.rsync-exclude
+/deploy-hooks/build-before.yml
+/group_vars/all/mail.yml
+/group_vars/all/vault.yml
+/group_vars/development/vault.yml
+/group_vars/development/wordpress_sites.yml
+/group_vars/production/vault.yml
+/group_vars/production/wordpress_sites.yml
+/group_vars/staging/vault.yml
+/group_vars/staging/wordpress_sites.yml
+/hosts/development
+/hosts/production
+/hosts/staging
+/server.yml
+
+# Manually check:
+/group_vars/all/main.yml
+/group_vars/all/users.yml
+/vagrant.default.yml

--- a/README.md
+++ b/README.md
@@ -54,10 +54,26 @@ example.com/      # → Root folder for the project
 See a complete working example in the [roots-example-project.com repo](https://github.com/roots/roots-example-project.com).
 
 1. Create a new project directory: `$ mkdir example.com && cd example.com`
-2. Clone Trellis: `$ git clone --depth=1 git@github.com:roots/trellis.git && rm -rf trellis/.git`
+2. Clone Trellis: `$ git clone --depth=1 git@github.com:Fatsoma/trellis.git && rm -rf trellis/.git`
 3. Clone Bedrock: `$ git clone --depth=1 git@github.com:roots/bedrock.git site && rm -rf site/.git`
 
 Windows user? [Read the Windows docs](https://roots.io/trellis/docs/windows/) for slightly different installation instructions. VirtualBox is known to have poor performance in Windows — use VMware or [see some possible solutions](https://discourse.roots.io/t/virtualbox-performance-in-windows/3932).
+
+## Update trellis
+
+Clone Fatsoma fork of trellis to your preferred location or pull the latest changes if you already have a clone.
+
+```sh
+git clone git@github.com:Fatsoma/trellis.git $TRELLIS_DIR
+```
+
+Copy files from trellis into your project trellis directory (run from your clone of trellis):
+
+```sh
+PROJECT_DIR=~/code/wp    # set to your project directory
+
+rsync -av --exclude-from .rsync-exclude ./ "${PROJECT_DIR}/trellis"
+```
 
 ## Local development setup
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ PROJECT_DIR=~/code/wp    # set to your project directory
 rsync -av --exclude-from .rsync-exclude ./ "${PROJECT_DIR}/trellis"
 ```
 
+Check for differences in:
+
+```
+group_vars/all/main.yml
+group_vars/all/users.yml
+vagrant.default.yml
+```
+
 ## Local development setup
 
 1. Configure your WordPress sites in `group_vars/development/wordpress_sites.yml` and in `group_vars/development/vault.yml`


### PR DESCRIPTION
Exclude example files that are not expected to have significant changes in
updates to trellis. Sample usage:

rsync -av --exclude-from .rsync-exclude ./ /path/to/wp-project/trellis