### PR TITLE
Disable X-Content-Type-Options

### DIFF
--- a/roles/nginx/templates/h5bp/directive-only/extra-security.conf
+++ b/roles/nginx/templates/h5bp/directive-only/extra-security.conf
@@ -4,7 +4,7 @@
 
 # MIME type sniffing security protection
 #	There are very few edge cases where you wouldn't want this enabled.
-add_header X-Content-Type-Options nosniff always;
+# add_header X-Content-Type-Options nosniff always;
 
 # The X-XSS-Protection header is used by Internet Explorer version 8+
 # The header instructs IE to enable its inbuilt anti-cross-site scripting filter.


### PR DESCRIPTION
At the moment there is issues with webpack injecting styles with incorrect header types on local watch commands. This is a temporary work around whilst the issue is resolved.

In future we may consider conditionally disabling this for development envs and make this an Ansible managed file. I’m closely monitoring this in the discourse and GH issue