### PR TITLE
Lint [502] tasks should be named in mounted-volume

### DIFF
--- a/roles/mounted-volume/tasks/main.yml
+++ b/roles/mounted-volume/tasks/main.yml
@@ -4,8 +4,8 @@
 #     var: item.value.mounted_volume
 #   with_dict: "{{ wordpress_sites }}"
 
-# Check if the root directory already exists
-- stat:
+- name: Check if the root directory already exists
+  stat:
     path: "{{ www_root }}"
   register: root_configured
 


### PR DESCRIPTION
Ansible-lint suggestion: Name tasks in mounted-volume role