### PR TITLE
Update rsync instructions

### DIFF
--- a/.rsync-exclude
+++ b/.rsync-exclude
@@ -1,6 +1,8 @@
 # Excludes:
 /.git
 /.rsync-exclude
+/.circleci
+/.github
 /deploy-hooks/build-before.yml
 /group_vars/all/mail.yml
 /group_vars/all/vault.yml

--- a/README.md
+++ b/README.md
@@ -97,7 +97,14 @@ PROJECT_DIR=~/code/wp    # set to your project directory
 rsync -av --exclude-from .rsync-exclude ./ "${PROJECT_DIR}/trellis"
 ```
 
-Check for differences in:
+Check the changes made to files in `group_vars` - particularly for deletions as
+these are likely things that were added in the project:
+
+```sh
+git diff group_vars
+```
+
+Manually check for differences in:
 
 ```
 group_vars/all/main.yml


### PR DESCRIPTION
Clearer instructions on manual checks

* Check for differences in group_vars files that were synced
* Manually check (compare with your favourite diff tool) files in project
and trellis

Exclude `.circleci`, `.github` from rsync