### PR TITLE
Shorten letsencrypt loop output

### DIFF
--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -16,7 +16,7 @@ site_hosts_redirects: "{{ item.value.site_hosts | selectattr('redirects', 'defin
 site_hosts: "{{ site_hosts_canonical | union(site_hosts_redirects) }}"
 multisite_subdomains_wildcards: "{{ item.value.multisite.subdomains | default(false) | ternary( site_hosts_canonical | map('regex_replace', '^(www\\.)?(.*)$', '*.\\2') | list, [] ) }}"
 ssl_enabled: "{{ item.value.ssl is defined and item.value.ssl.enabled | default(false) }}"
-host_ssl_enabled: "{{ item.0.ssl is defined and (item.0.ssl.enabled | default(false)) }}"
+host_ssl_enabled: "{{ item.0.value.ssl is defined and (item.0.value.ssl.enabled | default(false)) }}"
 ssl_stapling_enabled: "{{ item.value.ssl is defined and item.value.ssl.stapling_enabled | default(true) }}"
 cron_enabled: "{{ site_env.disable_wp_cron and (not item.value.multisite.enabled | default(false) or (item.value.multisite.enabled | default(false) and item.value.multisite.cron | default(true))) }}"
 sites_use_ssl: "{{ wordpress_sites.values() | map(attribute='ssl') | selectattr('enabled') | list | count > 0 }}"

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -1,6 +1,6 @@
 sites_using_letsencrypt: "[{% for name, site in wordpress_sites.items() | list if site.ssl.enabled and site.ssl.provider | default('manual') == 'letsencrypt' %}{% for host in site.site_hosts %}'{{ host.canonical }}',{% endfor %}{% endfor %}]"
 site_uses_letsencrypt: ssl_enabled and item.value.ssl.provider | default('manual') == 'letsencrypt'
-site_host_uses_letsencrypt: host_ssl_enabled and item.0.ssl.provider | default('manual') == 'letsencrypt'
+site_host_uses_letsencrypt: host_ssl_enabled and item.0.value.ssl.provider | default('manual') == 'letsencrypt'
 missing_hosts: "{{ site_hosts | difference((current_hosts.results | selectattr('item.key', 'equalto', item.key) | selectattr('stdout_lines', 'defined') | sum(attribute='stdout_lines', start=[]) | map('trim') | list | join(' ')).split(' ')) }}"
 letsencrypt_cert_ids: "{ {% for item in (generate_cert_ids | default({'results':[{'skipped':True}]})).results if item is not skipped %}'{{ item.item.1.canonical }}':'{{ item.stdout }}', {% endfor %} }"
 

--- a/roles/letsencrypt/tasks/certificates.yml
+++ b/roles/letsencrypt/tasks/certificates.yml
@@ -4,18 +4,18 @@
   args:
     creates: "{{ letsencrypt_keys_dir }}/{{ item.1.canonical }}.key"
   when: site_host_uses_letsencrypt
-  with_subelements:
-    - "{{ wordpress_sites }}"
-    - site_hosts
+  loop: "{{ wordpress_sites | dict2items | subelements('value.site_hosts') }}"
+  loop_control:
+    label: "{{ item.0.key }} => {{ item.1.canonical }}"
 
 - name: Ensure correct permissions on private keys
   file:
     path: "{{ letsencrypt_keys_dir }}/{{ item.1.canonical }}.key"
     mode: 0600
   when: site_host_uses_letsencrypt
-  with_subelements:
-    - "{{ wordpress_sites }}"
-    - site_hosts
+  loop: "{{ wordpress_sites | dict2items | subelements('value.site_hosts') }}"
+  loop_control:
+    label: "{{ item.0.key }} => {{ item.1.canonical }}"
 
 - name: Generate Lets Encrypt certificate IDs
   shell: |
@@ -28,9 +28,9 @@
   register: generate_cert_ids
   changed_when: false
   when: site_host_uses_letsencrypt
-  with_subelements:
-    - "{{ wordpress_sites }}"
-    - site_hosts
+  loop: "{{ wordpress_sites | dict2items | subelements('value.site_hosts') }}"
+  loop_control:
+    label: "{{ item.0.key }} => {'canonical': {{ item.1.canonical }}, 'redirects': {{ item.1.redirects | default([]) }}}"
   tags: [wordpress, wordpress-setup, nginx-includes, nginx-sites]
 
 - name: Generate CSRs
@@ -39,9 +39,9 @@
     executable: /bin/bash
     creates: "{{ acme_tiny_data_directory }}/csrs/{{ item.1.canonical }}-{{ letsencrypt_cert_ids[item.1.canonical] }}.csr"
   when: site_host_uses_letsencrypt
-  with_subelements:
-    - "{{ wordpress_sites }}"
-    - site_hosts
+  loop: "{{ wordpress_sites | dict2items | subelements('value.site_hosts') }}"
+  loop_control:
+    label: "{{ item.0.key }} => {'canonical': {{ item.1.canonical }}, 'redirects': {{ item.1.redirects | default([]) }}}"
 
 - name: Generate certificate renewal script
   template:


### PR DESCRIPTION
Related to https://fatsoma.atlassian.net/browse/PLAT-1663

Based on https://github.com/Fatsoma/wp-public-3/pull/1686

Set `loop_control` label to reduce output on `site_hosts` loops.
This changes the loop variables to be like `item.0.value` rather than `item.0`