### PR TITLE
Fix vagrant configs

### DIFF
--- a/.rsync-exclude
+++ b/.rsync-exclude
@@ -1,5 +1,6 @@
 # Excludes:
 /.git
+/.gitattributes
 /.rsync-exclude
 /.circleci
 /.github

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,11 +89,11 @@ Vagrant.configure('2') do |config|
     fail_with_message "vagrant-bindfs missing, please install the plugin with this command:\nvagrant plugin install vagrant-bindfs"
   else
     trellis_config.wordpress_sites.each_pair do |name, site|
-      config.vm.synced_folder local_site_path(site), nfs_path(name), type: 'nfs'
+      config.vm.synced_folder local_site_path(site), nfs_path(name), type: 'nfs', nfs_udp: false
       config.bindfs.bind_folder nfs_path(name), remote_site_path(name, site), u: 'vagrant', g: 'www-data', o: 'nonempty'
     end
 
-    config.vm.synced_folder ANSIBLE_PATH, '/ansible-nfs', type: 'nfs'
+    config.vm.synced_folder ANSIBLE_PATH, '/ansible-nfs', type: 'nfs', nfs_udp: false
     config.bindfs.bind_folder '/ansible-nfs', ANSIBLE_PATH_ON_VM, o: 'nonempty', p: '0644,a+D'
     config.bindfs.bind_folder bin_path, bin_path, perms: '0755'
   end
@@ -105,6 +105,7 @@ Vagrant.configure('2') do |config|
       mount_options: folder.fetch('mount_options', [])
     }
 
+    options[:nfs_udp] = folder.fetch('nfs_udp', false) if folder.fetch('type', 'nfs') == 'nfs'
     destination_folder = folder.fetch('bindfs', true) ? nfs_path(folder['destination']) : folder['destination']
 
     config.vm.synced_folder folder['local_path'], destination_folder, options

--- a/group_vars/development/main.yml
+++ b/group_vars/development/main.yml
@@ -3,3 +3,5 @@ env: development
 ferm_enabled: false
 mysql_root_password: "{{ vault_mysql_root_password }}" # Define this variable in group_vars/development/vault.yml
 web_user: vagrant
+composer_home_owner: vagrant
+composer_home_group: vagrant

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -2,8 +2,8 @@
 vagrant_ip: '192.168.50.5'
 vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
-vagrant_box: 'bento/ubuntu-18.04'
-vagrant_box_version: '>= 201807.12.0'
+vagrant_box: 'generic/ubuntu18.04'
+vagrant_box_version: '>= 3.2.20'
 vagrant_ansible_version: '2.7.12'
 vagrant_skip_galaxy: false
 vagrant_mount_type: 'nfs'

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -4,7 +4,7 @@ vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'generic/ubuntu18.04'
 vagrant_box_version: '>= 3.2.20'
-vagrant_ansible_version: '2.7.12'
+vagrant_ansible_version: '2.8.4'
 vagrant_skip_galaxy: false
 vagrant_mount_type: 'nfs'
 

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -1,5 +1,5 @@
 ---
-vagrant_ip: '192.168.50.5'
+vagrant_ip: '192.168.56.5'
 vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'generic/ubuntu18.04'

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -5,7 +5,7 @@ vagrant_memory: 1024 # in MB
 vagrant_box: 'generic/ubuntu18.04'
 vagrant_box_version: '>= 3.2.20'
 vagrant_ansible_version: '2.8.4'
-vagrant_skip_galaxy: false
+vagrant_skip_galaxy: true
 vagrant_mount_type: 'nfs'
 
 vagrant_install_plugins: true


### PR DESCRIPTION
Based on https://github.com/Fatsoma/wp-public-3/pull/2073

* Use IP address in default allowed range for VirtualBox
* Use generic Ubuntu box (as this is currently available)
* Set NFS to not use UDP (NFS 4 defaults to not allow UDP due to security concerns)
* Use ansible 2.8.4 (adds support for `dict2items` which we use in our collections)
* Skip ansible galaxy update on vagrant (the api has been replaced and now requires `ansible-core >= 2.13.9`)